### PR TITLE
Teste criado com 100%

### DIFF
--- a/src/test/java/com/fiapx/videoprocessor/core/application/exceptions/ResourceNotFoundExceptionTest.java
+++ b/src/test/java/com/fiapx/videoprocessor/core/application/exceptions/ResourceNotFoundExceptionTest.java
@@ -1,0 +1,21 @@
+package com.fiapx.videoprocessor.core.application.exceptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+public class ResourceNotFoundExceptionTest {
+
+
+    static class DummyClass {}
+
+    @Test
+    void constructor_withClass_shouldSetMessageCorrectly() {
+        ResourceNotFoundException ex = new ResourceNotFoundException(DummyClass.class);
+        assertEquals("DummyClass not found.", ex.getMessage());
+    }
+
+    @Test
+    void constructor_withClassAndInfo_shouldSetMessageCorrectly() {
+        ResourceNotFoundException ex = new ResourceNotFoundException(DummyClass.class, "ID 123");
+        assertEquals("DummyClass not found. ID 123", ex.getMessage());
+    }
+}


### PR DESCRIPTION
Teste criado cobrindo a classe alvo com 100%
![image](https://github.com/user-attachments/assets/38398c87-744f-41a5-871d-bd86df070f2b)
